### PR TITLE
Switch from positional args to an input hash

### DIFF
--- a/src/arg-to-js.js
+++ b/src/arg-to-js.js
@@ -1,11 +1,11 @@
 import * as t from 'babel-types';
 import argValueToJS from './arg-value-to-js';
 
-export default function argToJS(key, args, operationName, clientVar, variablesVar) {
+export default function argToJS(key, args, operationName, config) {
   const argFields = args.map((argument) => {
     return t.objectProperty(
       t.identifier(argument.name.value),
-      argValueToJS(argument.value, operationName, clientVar, variablesVar)
+      argValueToJS(argument.value, operationName, config)
     );
   });
 

--- a/src/arg-value-to-js.js
+++ b/src/arg-value-to-js.js
@@ -1,13 +1,13 @@
 import * as t from 'babel-types';
 import variableReference from './variable-reference';
 
-export default function argValueToJS(argumentValue, operationName, clientVar, variablesVar) {
+export default function argValueToJS(argumentValue, operationName, config) {
   switch (argumentValue.kind) {
     case 'StringValue':
       return t.stringLiteral(argumentValue.value);
     case 'EnumValue':
       return t.callExpression(
-        t.memberExpression(clientVar, t.identifier('enum')),
+        t.memberExpression(config.clientVar, t.identifier('enum')),
         [t.stringLiteral(argumentValue.value)]
       );
     case 'IntValue':
@@ -17,13 +17,18 @@ export default function argValueToJS(argumentValue, operationName, clientVar, va
     case 'BooleanValue':
       return t.booleanLiteral(argumentValue.value);
     case 'ListValue':
-      return t.arrayExpression(argumentValue.values.map((value) => argValueToJS(value, operationName, clientVar, variablesVar)));
+      return t.arrayExpression(argumentValue.values.map((value) => {
+        return argValueToJS(value, operationName, config);
+      }));
     case 'ObjectValue':
       return t.objectExpression(argumentValue.fields.map((field) => {
-        return t.objectProperty(t.identifier(field.name.value), argValueToJS(field.value, operationName, clientVar, variablesVar));
+        return t.objectProperty(
+          t.identifier(field.name.value),
+          argValueToJS(field.value, operationName, config)
+        );
       }));
     case 'Variable':
-      return variableReference(operationName, argumentValue, variablesVar);
+      return variableReference(operationName, argumentValue, config);
     default:
       throw Error(`Unrecognized argument value type "${argumentValue.kind}"`);
   }

--- a/src/construct-js-variable-definition.js
+++ b/src/construct-js-variable-definition.js
@@ -12,19 +12,19 @@ function typeConstraint(variableAst) {
   }
 }
 
-export default function constructJSVariableDefinition(variableAst, clientVar, variablesVar) {
+export default function constructJSVariableDefinition(variableAst, config) {
   const variableConstructionArgs = [
     t.stringLiteral(variableAst.variable.name.value),
     t.stringLiteral(typeConstraint(variableAst.type))
   ];
 
   if (variableAst.defaultValue) {
-    variableConstructionArgs.push(argValueToJS(variableAst.defaultValue, null, clientVar, variablesVar));
+    variableConstructionArgs.push(argValueToJS(variableAst.defaultValue, null, config));
   }
 
   return t.callExpression(
     t.memberExpression(
-      clientVar,
+      config.clientVar,
       t.identifier('variable')
     ),
     variableConstructionArgs

--- a/src/declare-variables.js
+++ b/src/declare-variables.js
@@ -13,13 +13,13 @@ function nameFromOperation(operationDefinition) {
   return operationDefinition.name ? operationDefinition.name.value : '__defaultOperation__';
 }
 
-function variablesDeclaration(variablesVar) {
+function variablesDeclaration({variablesVar}) {
   return t.variableDeclaration('const', [
     t.variableDeclarator(variablesVar, t.objectExpression([]))
   ]);
 }
 
-function variablesHashForOperationDeclaration(variablesVar, operationName) {
+function variablesHashForOperationDeclaration(operationName, {variablesVar}) {
   return t.expressionStatement(
     t.assignmentExpression(
       '=',
@@ -32,23 +32,23 @@ function variablesHashForOperationDeclaration(variablesVar, operationName) {
   );
 }
 
-function declareVariableForOperation(variablesVar, operationName, variableAst) {
+function declareVariableForOperation(operationName, variableAst, config) {
   return t.expressionStatement(
     t.assignmentExpression(
       '=',
       t.memberExpression(
         t.memberExpression(
-          variablesVar,
+          config.variablesVar,
           t.identifier(operationName)
         ),
         t.identifier(variableAst.variable.name.value)
       ),
-      constructJSVariableDefinition(variableAst, t.identifier('client'), variablesVar)
+      constructJSVariableDefinition(variableAst, config)
     )
   );
 }
 
-export default function declareVariables(graphqlAst, variablesVar) {
+export default function declareVariables(graphqlAst, config) {
   const operationsWithVariables = graphqlAst
     .definitions
     .filter(isOperationDefinition)
@@ -59,17 +59,17 @@ export default function declareVariables(graphqlAst, variablesVar) {
   }
 
   return [
-    variablesDeclaration(variablesVar),
+    variablesDeclaration(config),
     ...(
       operationsWithVariables
         .map((operationDefinition) => {
           const operationName = nameFromOperation(operationDefinition);
 
           return [
-            variablesHashForOperationDeclaration(variablesVar, operationName),
+            variablesHashForOperationDeclaration(operationName, config),
             ...(
               operationDefinition.variableDefinitions.map((variableAst) => {
-                return declareVariableForOperation(variablesVar, operationName, variableAst);
+                return declareVariableForOperation(operationName, variableAst, config);
               })
             )
           ];

--- a/src/document-to-js-ast.js
+++ b/src/document-to-js-ast.js
@@ -15,7 +15,7 @@ function insertObjectDeclaration(nodes, identifier) {
   ]));
 }
 
-function declareDocument(nodes, clientVar, documentVar) {
+function declareDocument(nodes, {documentVar, clientVar}) {
   nodes.push(t.variableDeclaration('const', [
     t.variableDeclarator(documentVar,
       t.callExpression(
@@ -26,10 +26,10 @@ function declareDocument(nodes, clientVar, documentVar) {
   ]));
 }
 
-export default function documentToJSAst(graphQLAst, clientVar, documentVar, spreadsVar, variablesVar) {
+export default function documentToJSAst(graphQLAst, config) {
   const jsGraphQLNodes = [];
 
-  declareDocument(jsGraphQLNodes, clientVar, documentVar);
+  declareDocument(jsGraphQLNodes, config);
 
   const sortedgraphQLAst = Object.assign(
     {},
@@ -39,14 +39,14 @@ export default function documentToJSAst(graphQLAst, clientVar, documentVar, spre
   const fragmentDefinitons = extractFragmentDefinitons(sortedgraphQLAst.definitions);
 
   if (fragmentDefinitons.length) {
-    insertObjectDeclaration(jsGraphQLNodes, spreadsVar);
+    insertObjectDeclaration(jsGraphQLNodes, config.spreadsVar);
   }
 
-  jsGraphQLNodes.push(...declareVariables(graphQLAst, variablesVar));
+  jsGraphQLNodes.push(...declareVariables(graphQLAst, config));
 
   visit(sortedgraphQLAst, {
-    FragmentDefinition: fragmentVisitor(jsGraphQLNodes, clientVar, documentVar, spreadsVar, variablesVar),
-    OperationDefinition: operationVisitor(jsGraphQLNodes, clientVar, documentVar, spreadsVar, variablesVar)
+    FragmentDefinition: fragmentVisitor(jsGraphQLNodes, config),
+    OperationDefinition: operationVisitor(jsGraphQLNodes, config)
   });
 
   return jsGraphQLNodes;

--- a/src/fragment-visitor.js
+++ b/src/fragment-visitor.js
@@ -1,21 +1,21 @@
 import * as t from 'babel-types';
 import selectionSetToJS from './selection-set-to-js';
 
-export default function fragmentVisitor(jsNodes, clientVar, documentVar, spreadsVar, variablesVar) {
+export default function fragmentVisitor(jsNodes, config) {
   return function visitor(node) {
     const selectionRootName = 'root';
     const fragmentDefinitionArguments = [
       t.stringLiteral(node.name.value),
       t.stringLiteral(node.typeCondition.name.value),
-      selectionSetToJS(node.selectionSet, selectionRootName, null, spreadsVar, clientVar, variablesVar)
+      selectionSetToJS(node.selectionSet, selectionRootName, null, config)
     ];
 
     jsNodes.push(t.expressionStatement(
       t.assignmentExpression(
         '=',
-        t.memberExpression(spreadsVar, t.identifier(node.name.value)),
+        t.memberExpression(config.spreadsVar, t.identifier(node.name.value)),
         t.callExpression(
-          t.memberExpression(documentVar, t.identifier('defineFragment')),
+          t.memberExpression(config.documentVar, t.identifier('defineFragment')),
           fragmentDefinitionArguments
         )
       )

--- a/src/index.js
+++ b/src/index.js
@@ -3,26 +3,42 @@ import * as t from 'babel-types';
 import generate from 'babel-generator';
 import documentToJSAst from './document-to-js-ast';
 
-export function transformToAst(
-  graphqlCode,
+const defaults = {
+  clientVar: 'client',
+  documentVar: 'document',
+  spreadsVar: 'spreads',
+  variablesVar: 'variables'
+};
+
+export function transformToAst(graphqlCode, {
   clientVar = 'client',
   documentVar = 'document',
   spreadsVar = 'spreads',
   variablesVar = 'variables'
-) {
+} = defaults) {
   const graphQLAst = parse(graphqlCode);
+  const vars = {
+    clientVar: t.identifier(clientVar),
+    documentVar: t.identifier(documentVar),
+    spreadsVar: t.identifier(spreadsVar),
+    variablesVar: t.identifier(variablesVar)
+  };
 
-  return documentToJSAst(
-    graphQLAst,
-    t.identifier(clientVar),
-    t.identifier(documentVar),
-    t.identifier(spreadsVar),
-    t.identifier(variablesVar)
-  );
+  return documentToJSAst(graphQLAst, vars);
 }
 
-export default function transformToCode(graphqlCode, clientVar = 'client', documentVar = 'document', spreadsVar = 'spreads') {
-  const jsAst = transformToAst(graphqlCode, clientVar, documentVar, spreadsVar);
+export default function transformToCode(graphqlCode, {
+  clientVar = 'client',
+  documentVar = 'document',
+  spreadsVar = 'spreads',
+  variablesVar = 'variables'
+} = defaults) {
+  const jsAst = transformToAst(graphqlCode, {
+    clientVar,
+    documentVar,
+    spreadsVar,
+    variablesVar
+  });
 
   return `${generate(t.program(jsAst)).code}\n`;
 }

--- a/src/operation-visitor.js
+++ b/src/operation-visitor.js
@@ -9,7 +9,7 @@ function applyName(graphQLNode, argList) {
   }
 }
 
-function applyVariables(operationDefinition, argList, variablesVar) {
+function applyVariables(operationDefinition, argList, config) {
   const variableDefinitions = operationDefinition.variableDefinitions;
 
   if (!(variableDefinitions && variableDefinitions.length)) {
@@ -18,7 +18,7 @@ function applyVariables(operationDefinition, argList, variablesVar) {
 
   const name = operationName(operationDefinition);
 
-  argList.push(referenceVariablesInOperationDeclaration(name, variableDefinitions, variablesVar));
+  argList.push(referenceVariablesInOperationDeclaration(name, variableDefinitions, config));
 }
 
 function operationFactoryFunction(graphQLNode) {
@@ -32,23 +32,22 @@ function operationFactoryFunction(graphQLNode) {
   }
 }
 
-export default function operationVisitor(jsNodes, clientVar, documentVar, spreadsVar, variablesVar) {
+export default function operationVisitor(jsNodes, config) {
   return function visitor(node) {
 
-    // node.name.value
     const selectionRootName = 'root';
     const operationDefinitionArgs = [];
     const name = operationName(node);
 
     applyName(node, operationDefinitionArgs);
-    applyVariables(node, operationDefinitionArgs, variablesVar);
+    applyVariables(node, operationDefinitionArgs, config);
 
     operationDefinitionArgs.push(
-      selectionSetToJS(node.selectionSet, selectionRootName, name, spreadsVar, clientVar, variablesVar)
+      selectionSetToJS(node.selectionSet, selectionRootName, name, config)
     );
 
     jsNodes.push(t.expressionStatement(t.callExpression(
-      t.memberExpression(documentVar, t.identifier(operationFactoryFunction(node))),
+      t.memberExpression(config.documentVar, t.identifier(operationFactoryFunction(node))),
       operationDefinitionArgs
     )));
   };

--- a/src/reference-variables-in-operation-declaration.js
+++ b/src/reference-variables-in-operation-declaration.js
@@ -1,8 +1,8 @@
 import * as t from 'babel-types';
 import variableReference from './variable-reference';
 
-export default function referenceVariablesInOperationDeclaration(operationName, variableDefinitions, variablesVar) {
+export default function referenceVariablesInOperationDeclaration(operationName, variableDefinitions, config) {
   return t.arrayExpression(variableDefinitions.map((variableAst) => {
-    return variableReference(operationName, variableAst.variable, variablesVar);
+    return variableReference(operationName, variableAst.variable, config);
   }));
 }

--- a/src/selection-set-to-js.js
+++ b/src/selection-set-to-js.js
@@ -1,7 +1,7 @@
 import * as t from 'babel-types';
 import argToJS from './arg-to-js';
 
-function identifyOperation(selection, spreadsVar) {
+function identifyOperation(selection, {spreadsVar}) {
   switch (selection.kind) {
     case 'Field':
       return {
@@ -30,22 +30,22 @@ function applyAlias(options, selection) {
   }
 }
 
-function applyArguments(options, selection, operationName, clientVar, variablesVar) {
+function applyArguments(options, selection, operationName, config) {
   if (!(selection.arguments && selection.arguments.length)) {
     return;
   }
 
-  options.push(argToJS(t.identifier('args'), selection.arguments, operationName, clientVar, variablesVar));
+  options.push(argToJS(t.identifier('args'), selection.arguments, operationName, config));
 }
 
 // Returns the body of the block statement representing the selections
-export default function selectionSetToJS(selectionSet, parentSelectionName, operationName, spreadsVar, clientVar, variablesVar) {
+export default function selectionSetToJS(selectionSet, parentSelectionName, operationName, config) {
   const selections = selectionSet.selections.map((selection) => {
-    const {selectionConstructionArgs, operationMethodName, kind} = identifyOperation(selection, spreadsVar);
+    const {selectionConstructionArgs, operationMethodName, kind} = identifyOperation(selection, config);
     const fieldOptions = [];
 
     applyAlias(fieldOptions, selection);
-    applyArguments(fieldOptions, selection, operationName, clientVar, variablesVar);
+    applyArguments(fieldOptions, selection, operationName, config);
 
     // Add query options (i.e. alias and arguments) to the query
     if (fieldOptions.length) {
@@ -56,7 +56,7 @@ export default function selectionSetToJS(selectionSet, parentSelectionName, oper
       const fieldNameOrTypeConstraint = selectionConstructionArgs[0].value;
 
       selectionConstructionArgs.push(
-        selectionSetToJS(selection.selectionSet, fieldNameOrTypeConstraint, operationName, spreadsVar, clientVar, variablesVar)
+        selectionSetToJS(selection.selectionSet, fieldNameOrTypeConstraint, operationName, config)
       );
     }
 

--- a/src/variable-reference.js
+++ b/src/variable-reference.js
@@ -1,6 +1,6 @@
 import * as t from 'babel-types';
 
-export default function variableReference(operationName, variable, variablesVar) {
+export default function variableReference(operationName, variable, {variablesVar}) {
   return t.memberExpression(
     t.memberExpression(
       variablesVar,

--- a/test/arg-to-js-test.js
+++ b/test/arg-to-js-test.js
@@ -5,11 +5,15 @@ import * as t from 'babel-types';
 import argToJS from '../src/arg-to-js';
 
 suite('arg-to-js', () => {
+  const config = {
+    clientVar: t.identifier('client'),
+    variablesVar: t.identifier('variables')
+  };
 
   test('it converts scalar arguments', () => {
     const query = '{field(argName: "value")}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -19,7 +23,7 @@ suite('arg-to-js', () => {
   test('it converts multiple arguments', () => {
     const query = '{field(argOne: 1, argTwo: 2.5, argThree: true)}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -29,7 +33,7 @@ suite('arg-to-js', () => {
   test('it converts INPUT_OBJECT arguments', () => {
     const query = '{field(input: {argOne: true})}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -39,7 +43,7 @@ suite('arg-to-js', () => {
   test('it converts scalar list arguments', () => {
     const query = '{field(argName: ["value-one", 2, "value-three"])}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -49,7 +53,7 @@ suite('arg-to-js', () => {
   test('it converts list of list arguments', () => {
     const query = '{field(argName: [["value-one"], [2, "value-three"]])}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -59,7 +63,7 @@ suite('arg-to-js', () => {
   test('it converts list of INPUT_OBJECT arguments', () => {
     const query = '{field(argName: [{argOne: "value-one"}, {argTwo: 2, argThree: "value-three"}])}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -69,7 +73,7 @@ suite('arg-to-js', () => {
   test('it converts variables to client variables', () => {
     const query = '{field(argName: $value)}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -79,7 +83,7 @@ suite('arg-to-js', () => {
   test('it converts variables nested in arguments to client variables', () => {
     const query = '{field(argName: $value)}';
     const argumentsAst = parse(query).definitions[0].selectionSet.selections[0].arguments;
-    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argToJS(t.identifier('args'), argumentsAst, '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 

--- a/test/arg-value-to-js-test.js
+++ b/test/arg-value-to-js-test.js
@@ -5,10 +5,15 @@ import * as t from 'babel-types';
 import argValueToJS from '../src/arg-value-to-js';
 
 suite('arg-value-to-js', () => {
+  const config = {
+    clientVar: t.identifier('client'),
+    variablesVar: t.identifier('variables')
+  };
+
   test('it can convert string values', () => {
     const query = '{field(var: "value")}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '"value"');
   });
@@ -16,7 +21,7 @@ suite('arg-value-to-js', () => {
   test('it can convert enum values', () => {
     const query = '{field(var: VALUE)}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, 'client.enum("VALUE")');
   });
@@ -24,7 +29,7 @@ suite('arg-value-to-js', () => {
   test('it can convert int values', () => {
     const query = '{field(var: 1)}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '1');
   });
@@ -32,7 +37,7 @@ suite('arg-value-to-js', () => {
   test('it can convert float values', () => {
     const query = '{field(var: 1.5)}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '1.5');
   });
@@ -40,7 +45,7 @@ suite('arg-value-to-js', () => {
   test('it can convert boolean values', () => {
     const query = '{field(var: true)}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, 'true');
   });
@@ -48,7 +53,7 @@ suite('arg-value-to-js', () => {
   test('it can convert list values', () => {
     const query = '{field(var: ["one", "two", 3])}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '["one", "two", 3]');
   });
@@ -56,7 +61,7 @@ suite('arg-value-to-js', () => {
   test('it can convert INPUT_OBJECT values', () => {
     const query = '{field(var: {key: "value"})}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '{\n  key: "value"\n}');
   });
@@ -64,7 +69,7 @@ suite('arg-value-to-js', () => {
   test('it can convert list of list values', () => {
     const query = '{field(var: ["one", ["two", "three"]])}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '["one", ["two", "three"]]');
   });
@@ -72,7 +77,7 @@ suite('arg-value-to-js', () => {
   test('it can convert nested INPUT_OBJECT values', () => {
     const query = '{field(var: {key: {otherKey: true}, foo: "bar"})}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '{\n  key: {\n    otherKey: true\n  },\n  foo: "bar"\n}');
   });
@@ -80,7 +85,7 @@ suite('arg-value-to-js', () => {
   test('it can convert variables', () => {
     const query = '{field(var: $someVariable)}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, 'variables.__defaultOperation__.someVariable');
   });
@@ -88,7 +93,7 @@ suite('arg-value-to-js', () => {
   test('it can convert variables on named operations', () => {
     const query = 'query MyQuery {field(var: $someVariable)}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, 'MyQuery', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, 'MyQuery', config);
 
     assert.equal(generate(jsAst).code, 'variables.MyQuery.someVariable');
   });
@@ -96,7 +101,7 @@ suite('arg-value-to-js', () => {
   test('it can handle really complex queries', () => {
     const query = '{field(var: {argOne: ["one", "two", $three, {nestedArgOne: true, nestedArgTwo: TWO}], argTwo: {one: [2.5, {three: true}]}})}';
     const valueAst = parse(query).definitions[0].selectionSet.selections[0].arguments[0].value;
-    const jsAst = argValueToJS(valueAst, '__defaultOperation__', t.identifier('client'), t.identifier('variables'));
+    const jsAst = argValueToJS(valueAst, '__defaultOperation__', config);
 
     assert.equal(generate(jsAst).code, '{\n  argOne: ["one", "two", variables.__defaultOperation__.three, {\n    nestedArgOne: true,\n    nestedArgTwo: client.enum("TWO")\n  }],\n  argTwo: {\n    one: [2.5, {\n      three: true\n    }]\n  }\n}');
   });

--- a/test/basic-query-transform-test.js
+++ b/test/basic-query-transform-test.js
@@ -16,7 +16,10 @@ suite('basic-query-transform-test', () => {
     const query = getFixture('basic-query.graphql');
     const expectedBuilderCode = getFixture('basic-query-with-custom-var.js');
 
-    const builderCode = transform(query, 'fancyClient', 'someOtherDocument');
+    const builderCode = transform(query, {
+      clientVar: 'fancyClient',
+      documentVar: 'someOtherDocument'
+    });
 
     assert.equal(builderCode, expectedBuilderCode);
   });

--- a/test/construct-js-variable-definiton-test.js
+++ b/test/construct-js-variable-definiton-test.js
@@ -5,10 +5,15 @@ import * as t from 'babel-types';
 import constructJSVariableDefinition from '../src/construct-js-variable-definition';
 
 suite('construct-js-variable-definition-test', () => {
+  const config = {
+    clientVar: t.identifier('client'),
+    variablesVar: t.identifier('variables')
+  };
+
   test('it can convert a typed variable', () => {
     const query = 'query ($var: Int) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -18,7 +23,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a typed variable with a default', () => {
     const query = 'query ($var: Boolean = true) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -28,7 +33,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a non-null typed variable', () => {
     const query = 'query ($var: Int!) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -38,7 +43,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a non-null typed variable with a default', () => {
     const query = 'query ($var: String! = "beans") {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -48,7 +53,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a list type variable', () => {
     const query = 'query ($var: [Things]) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -58,7 +63,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a list type variable with a default', () => {
     const query = 'query ($var: [Things] = [{stuff: true}]) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -68,7 +73,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a list type variable with non-null elements', () => {
     const query = 'query ($var: [AnEnumType!]) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -78,7 +83,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a list type variable with non-null elements with a default', () => {
     const query = 'query ($var: [AnEnumType!] = [BEANS]) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -88,7 +93,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a non-null list type variable with non-null elements', () => {
     const query = 'query ($var: [SomeOtherType!]!) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 
@@ -98,7 +103,7 @@ suite('construct-js-variable-definition-test', () => {
   test('it can convert a non-null list type variable with non-null elements with a default', () => {
     const query = 'query ($var: [SomeOtherType!]! = [{foo: {bar: "baz"}}]) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
-    const jsAst = constructJSVariableDefinition(variableAst, t.identifier('client'), t.identifier('variables'));
+    const jsAst = constructJSVariableDefinition(variableAst, config);
 
     const code = generate(jsAst).code;
 

--- a/test/declare-variables-test.js
+++ b/test/declare-variables-test.js
@@ -5,10 +5,15 @@ import generate from 'babel-generator';
 import declareVariables from '../src/declare-variables';
 
 suite('declare-variables-test', () => {
+  const config = {
+    clientVar: t.identifier('client'),
+    variablesVar: t.identifier('variables')
+  };
+
   test('it doesn\'t declare a variabels var when the document has no variables', () => {
     const query = '{field}';
     const graphqlAst = parse(query);
-    const jsAst = declareVariables(graphqlAst, t.identifier('variables'));
+    const jsAst = declareVariables(graphqlAst, config);
 
     assert.equal(jsAst.length, 0);
   });
@@ -16,7 +21,7 @@ suite('declare-variables-test', () => {
   test('it declares variables for a single query with variables', () => {
     const query = 'query ($id: ID!) { node(id: $id) { id } }';
     const graphqlAst = parse(query);
-    const jsAst = declareVariables(graphqlAst, t.identifier('variables'));
+    const jsAst = declareVariables(graphqlAst, config);
 
     const code = generate(t.program(jsAst)).code;
 
@@ -32,7 +37,10 @@ variables.__defaultOperation__.id = client.variable("id", "ID!");
   test('it recieves custom variables vars', () => {
     const query = 'query ($id: ID!) { node(id: $id) { id } }';
     const graphqlAst = parse(query);
-    const jsAst = declareVariables(graphqlAst, t.identifier('customVariables'));
+    const jsAst = declareVariables(graphqlAst, {
+      ...config,
+      variablesVar: t.identifier('customVariables')
+    });
 
     const code = generate(t.program(jsAst)).code;
 
@@ -48,7 +56,7 @@ customVariables.__defaultOperation__.id = client.variable("id", "ID!");
   test('it namespaces variables for named operations', () => {
     const query = 'mutation MyMutation ($id: ID!) { node(id: $id) { id } }';
     const graphqlAst = parse(query);
-    const jsAst = declareVariables(graphqlAst, t.identifier('variables'));
+    const jsAst = declareVariables(graphqlAst, config);
 
     const code = generate(t.program(jsAst)).code;
 
@@ -67,7 +75,7 @@ variables.MyMutation.id = client.variable("id", "ID!");
       mutation MyMutation ($sort: InputSortKeys) { updateField(sort: $sort) { id } }
     `;
     const graphqlAst = parse(query);
-    const jsAst = declareVariables(graphqlAst, t.identifier('variables'));
+    const jsAst = declareVariables(graphqlAst, config);
 
     const code = generate(t.program(jsAst)).code;
 

--- a/test/reference-variables-in-operation-declaration-test.js
+++ b/test/reference-variables-in-operation-declaration-test.js
@@ -5,13 +5,17 @@ import * as t from 'babel-types';
 import referenceVariablesInOperationDeclaration from '../src/reference-variables-in-operation-declaration';
 
 suite('reference-variables-in-operation-declaration-test', () => {
+  const config = {
+    variablesVar: t.identifier('variables')
+  };
+
   test('it can handle a single variable', () => {
     const query = 'query ($var: Int) {field}';
     const variableAsts = parse(query).definitions[0].variableDefinitions;
     const jsAst = referenceVariablesInOperationDeclaration(
       '__defaultOperation__',
       variableAsts,
-      t.identifier('variables')
+      config
     );
 
     const code = generate(jsAst).code;
@@ -25,7 +29,7 @@ suite('reference-variables-in-operation-declaration-test', () => {
     const jsAst = referenceVariablesInOperationDeclaration(
       '__defaultOperation__',
       variableAsts,
-      t.identifier('variables')
+      config
     );
 
     const code = generate(jsAst).code;
@@ -39,7 +43,7 @@ suite('reference-variables-in-operation-declaration-test', () => {
     const jsAst = referenceVariablesInOperationDeclaration(
       'MyGloriousMutation',
       variableAsts,
-      t.identifier('variables')
+      config
     );
 
     const code = generate(jsAst).code;

--- a/test/selection-set-to-js-test.js
+++ b/test/selection-set-to-js-test.js
@@ -5,12 +5,16 @@ import * as t from 'babel-types';
 import selectionSetToJS from '../src/selection-set-to-js';
 
 suite('selection-set-to-js-test', () => {
-  const varArgs = [t.identifier('spreads'), t.identifier('client'), t.identifier('variables')];
+  const config = {
+    spreadsVar: t.identifier('spreads'),
+    clientVar: t.identifier('client'),
+    variablesVar: t.identifier('variables')
+  };
 
   test('it can convert fields within a selection', () => {
     const query = '{fieldOne fieldTwo}';
     const selectionSetAst = parse(query).definitions[0].selectionSet;
-    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', ...varArgs);
+    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -20,7 +24,7 @@ suite('selection-set-to-js-test', () => {
   test('it can convert named fragments within a selection', () => {
     const query = '{...MyFragment}';
     const selectionSetAst = parse(query).definitions[0].selectionSet;
-    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', ...varArgs);
+    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -30,7 +34,7 @@ suite('selection-set-to-js-test', () => {
   test('it can convert aliased fields within a selection', () => {
     const query = '{fieldOne fieldTwo: fieldThree}';
     const selectionSetAst = parse(query).definitions[0].selectionSet;
-    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', ...varArgs);
+    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -40,7 +44,7 @@ suite('selection-set-to-js-test', () => {
   test('it can convert fields with arguments within a selection', () => {
     const query = '{fieldOne(fancy: true)}';
     const selectionSetAst = parse(query).definitions[0].selectionSet;
-    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', ...varArgs);
+    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -50,7 +54,7 @@ suite('selection-set-to-js-test', () => {
   test('it can convert fields with selections within a selection', () => {
     const query = '{fieldOne {nestedFieldOne nestedFieldTwo}}';
     const selectionSetAst = parse(query).definitions[0].selectionSet;
-    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', ...varArgs);
+    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -60,7 +64,7 @@ suite('selection-set-to-js-test', () => {
   test('it can convert fields with arguments and selections within a selection', () => {
     const query = '{fieldOne(extraFancy: $FancinessQuotient) {nestedFieldOne nestedFieldTwo}}';
     const selectionSetAst = parse(query).definitions[0].selectionSet;
-    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', ...varArgs);
+    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 
@@ -70,7 +74,7 @@ suite('selection-set-to-js-test', () => {
   test('it can convert inline fragments within a selection', () => {
     const query = '{... on TheThing {fieldOne, fieldTwo}}';
     const selectionSetAst = parse(query).definitions[0].selectionSet;
-    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', ...varArgs);
+    const jsAst = selectionSetToJS(selectionSetAst, 'root', '__defaultOperation__', config);
 
     const code = generate(jsAst).code;
 

--- a/test/variable-reference-test.js
+++ b/test/variable-reference-test.js
@@ -5,11 +5,14 @@ import * as t from 'babel-types';
 import variableReference from '../src/variable-reference';
 
 suite('variable-reference-test', () => {
+
   test('it can handle a variable for an unnamed operation', () => {
     const query = 'query ($var: Int) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
     const operationName = 'MyOperation';
-    const jsAst = variableReference(operationName, variableAst.variable, t.identifier('variables'));
+    const jsAst = variableReference(operationName, variableAst.variable, {
+      variablesVar: t.identifier('variables')
+    });
 
     const code = generate(jsAst).code;
 
@@ -20,7 +23,9 @@ suite('variable-reference-test', () => {
     const query = 'mutation ($var: Int) {field}';
     const variableAst = parse(query).definitions[0].variableDefinitions[0];
     const operationName = '__defaultOperation__';
-    const jsAst = variableReference(operationName, variableAst.variable, t.identifier('vars'));
+    const jsAst = variableReference(operationName, variableAst.variable, {
+      variablesVar: t.identifier('vars')
+    });
 
     const code = generate(jsAst).code;
 


### PR DESCRIPTION
This simplifies the method signatures so that instead of relying on a bunch of positional args, bits of data that are correctly configuration are passed around in a configuration hash