### PR TITLE
Remove director

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,3 @@
-director: stergios14
 owners:
   - minasmart
 classification: library


### PR DESCRIPTION
**Owners**: @minasmart
**Service**: [graphql-to-js-client-builder/production](https://services.shopify.io/services/graphql-to-js-client-builder/production)

Director ownership has been deprecated in favour of Product/Service Line ownership.

For more information on service ownership, you can read the docs in [Services DB](https://services.shopify.io/doc/ownership).
